### PR TITLE
Changed the `contents` permission to `write` to allow release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,6 @@ permissions:
     contents: write
     packages: read
     pull-requests: write
-
 jobs:
     release:
         runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,9 +4,10 @@ env:
     HUSKY: 0
 permissions:
     id-token: write
-    contents: read
+    contents: write
     packages: read
     pull-requests: write
+
 jobs:
     release:
         runs-on: ubuntu-latest


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release workflow permissions so it can make changes to repository contents during the release process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>3.0.17--canary.35.6b4367f.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @shopfront/bridge@3.0.17--canary.35.6b4367f.0
  # or 
  yarn add @shopfront/bridge@3.0.17--canary.35.6b4367f.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
