### PR TITLE
SHOPFRONT-10540 Embedded API - Payment options are ignored when updat…

### DIFF
--- a/src/APIs/Sale/SalePayment.ts
+++ b/src/APIs/Sale/SalePayment.ts
@@ -56,7 +56,9 @@ export class SalePayment {
             this.metaData = metaData;
         }
 
-        this.options = rest;
+        if(rest && Object.keys(rest).length > 0) {
+            this.options = rest;
+        }
     }
 
     /**

--- a/src/APIs/Sale/SalePayment.ts
+++ b/src/APIs/Sale/SalePayment.ts
@@ -49,7 +49,14 @@ export class SalePayment {
         this.amount = amount;
         this.cashout = cashout;
         this.status = status;
-        this.options = options;
+
+        const { metaData, ...rest } = options || {};
+
+        if(metaData) {
+            this.metaData = metaData;
+        }
+
+        this.options = rest;
     }
 
     /**

--- a/src/Utilities/SaleCreate.ts
+++ b/src/Utilities/SaleCreate.ts
@@ -19,6 +19,7 @@ export interface SalePaymentData {
     rounding: number;
     cashout: number;
     metaData: Record<string, unknown>;
+    subType: undefined | string;
 }
 
 export interface SaleData extends BaseSaleData {
@@ -88,6 +89,7 @@ export function buildSaleData(sale: Sale): SaleData {
             rounding: payment.getRounding() || 0,
             cashout : payment.getCashout() || 0,
             metaData: payment.getMetaData(),
+            subType : payment.getOptions()?.subtype,
         })),
         isCancellable: sale.getIsCancellable(),
     };

--- a/tests/unit/CreateSale.test.ts
+++ b/tests/unit/CreateSale.test.ts
@@ -1,0 +1,117 @@
+import { assert, suite } from "@onshopfront/core/tests";
+import type { SaleData } from "../../src/APIs/Sale/BaseSale.js";
+import { Sale } from "../../src/APIs/Sale/Sale.js";
+import { SalePayment, SalePaymentStatus } from "../../src/APIs/Sale/SalePayment.js";
+import { buildSaleData } from "../../src/Utilities/SaleCreate.js";
+
+const generateBlankSaleData = (): SaleData => {
+    return {
+        internalId    : "sale-id",
+        register      : "register-id",
+        customer      : null,
+        linkedTo      : "",
+        orderReference: "",
+        metaData      : {},
+        refundReason  : "",
+        priceSet      : null,
+        isCancellable : true,
+        products      : [],
+        payments      : [],
+        totals        : {
+            sale    : 0,
+            paid    : 0,
+            savings : 0,
+            discount: 0,
+        },
+        notes: {
+            internal: "",
+            sale    : "",
+        },
+    };
+};
+
+suite("Testing the functions in the `SaleCreate` file", () => {
+    suite("Testing the `buildSaleData` function", () => {
+        test("The payment data can be built correctly", () => {
+            const sale = new Sale({
+                ...generateBlankSaleData(),
+                payments: [
+                    new SalePayment(
+                        "sale-payment-a-id",
+                        50,
+                        0,
+                        SalePaymentStatus.APPROVED,
+                        {
+                            metaData: {
+                                key: "value",
+                            },
+                            subtype: "VISA",
+                        }
+                    ),
+                    new SalePayment(
+                        "sale-payment-b-id",
+                        14.99,
+                        0,
+                        SalePaymentStatus.APPROVED,
+                        {
+                            metaData: {},
+                        }
+                    ),
+                ],
+                totals: {
+                    sale    : 64.99,
+                    paid    : 64.99,
+                    savings : 0,
+                    discount: 0,
+                },
+            });
+
+            assert(buildSaleData(sale)).deepStrictEquals({
+                internalId: "sale-id",
+                register  : "register-id",
+                notes     : {
+                    internal: "",
+                    sale    : "",
+                },
+                totals: {
+                    sale    : 64.99,
+                    paid    : 64.99,
+                    savings : 0,
+                    discount: 0,
+                },
+                linkedTo      : "",
+                orderReference: "",
+                refundReason  : "",
+                priceSet      : null,
+                metaData      : {},
+                customer      : null,
+                products      : [],
+                payments      : [
+                    {
+                        method  : "sale-payment-a-id",
+                        type    : undefined,
+                        amount  : 50,
+                        status  : "completed",
+                        rounding: 0,
+                        cashout : 0,
+                        metaData: {
+                            key: "value",
+                        },
+                        subType: "VISA",
+                    },
+                    {
+                        method  : "sale-payment-b-id",
+                        type    : undefined,
+                        amount  : 14.99,
+                        status  : "completed",
+                        rounding: 0,
+                        cashout : 0,
+                        metaData: {},
+                        subType : undefined,
+                    },
+                ],
+                isCancellable: true,
+            });
+        });
+    });
+});

--- a/tests/unit/CurrentSale.test.ts
+++ b/tests/unit/CurrentSale.test.ts
@@ -59,7 +59,7 @@ beforeAll(() => {
 });
 
 afterEach(async () => {
-    sale.clearSale();
+    await sale.clearSale();
 });
 
 suite("Testing the mocked `CurrentSale` class behaves properly", () => {


### PR DESCRIPTION
After this is merged, I'll need to update the POS code too.

I've only created a single test for this as it's running on an older version of Core and therefore the testing library is not the latest version. Once I'm able to update to the latest core version (not this ticket), I'll start building out a proper testing library.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sale payment information now supports optional payment subtypes.
  * Payment metadata is retained separately and included when sale details are created.

* **Bug Fixes**
  * Improved the accuracy and consistency of generated sale data, including payment details, totals and status information.

* **Tests**
  * Added broader coverage for sale creation and payment conversion scenarios.
  * Improved test cleanup to ensure sales are cleared reliably between tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>3.0.18--canary.36.7d7f18c.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @shopfront/bridge@3.0.18--canary.36.7d7f18c.0
  # or 
  yarn add @shopfront/bridge@3.0.18--canary.36.7d7f18c.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
